### PR TITLE
Update deps with cargo upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.86"
+anyhow = "1.0.98"
 base64 = "0.22.1"
-serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
-wit-bindgen = "0.41.0"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
+wit-bindgen = "0.43.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
-uuid = { version = "1.10.0", features = ["v4"] }
+uuid = { version = "1.17.0", features = ["v4"] }


### PR DESCRIPTION
```
$ cargo upgrade

 Checking clickhouse-component's dependencies
name       old req compatible latest  new req
====       ======= ========== ======  =======
anyhow     1.0.86  1.0.98     1.0.98  1.0.98 
serde      1.0.204 1.0.219    1.0.219 1.0.219
serde_json 1.0.120 1.0.140    1.0.140 1.0.140
uuid       1.10.0  1.17.0     1.17.0  1.17.0 

Checking clickhouse-component's dependencies
name        old req compatible latest new req note        
====        ======= ========== ====== ======= ====        
wit-bindgen 0.41.0  0.41.0     0.43.0 0.41.0  incompatible

```